### PR TITLE
Emphasize "how" and "when" on page 73.

### DIFF
--- a/rre_errata.htm
+++ b/rre_errata.htm
@@ -82,6 +82,8 @@ Formatting issues:
 <br><br>
 <b>Page 61</b>, there is a paragraph style quotation by Dennis DeBruler.  The page layout should be adjusted to display that as a block quote.
 <br><br>
+<b>Page 73</b>, "how" and "when" in the second sentence of the first paragraph should be emphasized or italicized.
+<br><br>
 We would also like to thank those people who have contributed
 corrections: A. Lester Buck III, Bryan Donovan, Katrina Owen, Nate Bibler, Sonia Hamilton.
 


### PR DESCRIPTION
It would be more clear to the reader to emphasize the "how" and "when" of the first paragraph:

> But just because you know _how_ doesn't mean you know _when_.
